### PR TITLE
switch to the devteam's package_samtools_0_1_19

### DIFF
--- a/galaxy/wrapper/tool_dependencies.xml
+++ b/galaxy/wrapper/tool_dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool_dependency>
     <package name="samtools" version="0.1.19">
-        <repository name="package_samtools_0_1_19" owner="iuc" prior_installation_required="True" />
+        <repository name="package_samtools_0_1_19" owner="devteam" prior_installation_required="True" />
     </package>
     <package name="numpy" version="1.9">
         <repository name="package_numpy_1_9" owner="iuc" prior_installation_required="True" />


### PR DESCRIPTION
The IUC package is failing to install on test.galaxyproject.org. The devteam's package for the same dependency uses pre-compiled binaries and works out of the box. I created an issue for this here: https://github.com/galaxyproject/tools-iuc/issues/60

It might be worth to switch to the devteam's pre-compiled binaries if possible even if the issue above is solved. Hence this PR.

Sources of the packages:
https://github.com/galaxyproject/tools-devteam/blob/master/packages/package_samtools_0_1_19/tool_dependencies.xml
https://github.com/galaxyproject/tools-iuc/blob/master/packages/package_samtools_0_1_19/tool_dependencies.xml