### PR TITLE
Remove all references to and use of bigWigInfo

### DIFF
--- a/config/deepTools.cfg
+++ b/config/deepTools.cfg
@@ -2,8 +2,6 @@
 sort: sort
 samtools: samtools
 bedgraph_to_bigwig: bedGraphToBigWig
-# used for bigwigCompare
-bigwig_info: bigWigInfo
 
 [general]
 # if set to max/2 (no quotes around)

--- a/config/deepTools.cfg.default
+++ b/config/deepTools.cfg.default
@@ -2,8 +2,6 @@
 sort: sort
 samtools: samtools
 bedgraph_to_bigwig: bedGraphToBigWig
-# used for bigwigCompare
-bigwig_info: bigWigInfo
 
 [general]
 # if set to max/2 (no quotes around)

--- a/deeptools/config/__init__.py
+++ b/deeptools/config/__init__.py
@@ -54,7 +54,6 @@ if os.environ.get('DEEP_TOOLS_NO_CONFIG', False):
     config.set('external_tools', 'sort', 'sort')
     config.set('external_tools', 'samtools', 'samtools')
     config.set('external_tools', 'bedgraph_to_bigwig', 'bedGraphToBigWig')
-    config.set('external_tools', 'bigwig_info', 'bigWigInfo')
 
 else:
     import pkg_resources

--- a/deeptools/config/deeptools.cfg
+++ b/deeptools/config/deeptools.cfg
@@ -2,8 +2,6 @@
 sort: sort
 samtools: samtools
 bedgraph_to_bigwig: bedGraphToBigWig
-# used for bigwigCompare
-bigwig_info: bigWigInfo
 
 [general]
 # if set to max/2 (no quotes around)

--- a/deeptools/getScorePerBigWigBin.py
+++ b/deeptools/getScorePerBigWigBin.py
@@ -120,8 +120,7 @@ def countFragmentsInRegions_worker(chrom, start, end,
 
 def getChromSizes(bigwigFilesList):
     """
-    Get chromosome sizes from bigWig file by shell calling bigWigInfo
-    (UCSC tools).
+    Get chromosome sizes from bigWig file with pyBigWig
 
     Test dataset with two samples covering 200 bp.
     >>> test = Tester()
@@ -130,9 +129,6 @@ def getChromSizes(bigwigFilesList):
     >>> getChromSizes([test.bwFile1, test.bwFile2])
     ([('3R', 200L)], set([]))
     """
-    # The following lines are - with one exception ("bigWigInfo") -
-    # identical with the bw-reading part of deeptools/countReadsPerBin.py (FK)
-
     # check that the path to USCS bedGraphToBigWig as set in the config
     # is installed and is executable.
 

--- a/deeptools/writeBedGraph_bam_and_bw.py
+++ b/deeptools/writeBedGraph_bam_and_bw.py
@@ -13,7 +13,6 @@ import pyBigWig
 import mapReduce
 from utilities import getCommonChrNames
 from writeBedGraph import *
-import config as cfg
 from deeptools import bamHandler
 
 
@@ -175,7 +174,6 @@ def writeBedGraph(
         cCommon = []
         chromNamesAndSize = {}
         for bw in bigwigs:
-            inBlock = False
             bwh = pyBigWig.open(bw)
             for chromName, size in bwh.chroms():
                 if chromName in chromNamesAndSize:

--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -14,7 +14,7 @@ Requirements
 * numpy and scipy installed
 * pysam >= 0.8 and bx-python are required
 * samtools (preferably in your PATH)
-* 2 UCSC tools: bedGraphToBigWig, bigWigInfo (preferably in your PATH) 
+* 1 UCSC tool: bedGraphToBigWig (preferably in your PATH) 
 
 The easiest way to obtain **Python 2.7 together with numpy and scipy** is
 via the `Anaconda Scientific Python
@@ -62,11 +62,8 @@ check the website for the correct folder for your operating system) and make the
 
 	$ mkdir UCSCtools
 	$ cd UCSCtools
-	$ for PROGRAM in bedGraphToBigWig bigWigInfo
-		do
-			wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/${PROGRAM}
-			chmod +x ${PROGRAM}
-		done
+	$ wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
+	$ chmod +x bedGraphToBigWig
 
 4. Check whether the tools work (you should get a usage message)
 ::
@@ -118,8 +115,6 @@ or if you want a particular release, choose one from https://github.com/fidelram
 	sort: sort
 	samtools: samtools
 	bedgraph_to_bigwig: bedGraphToBigWig
-	# used for bigwigCompare
-	bigwig_info: bigWigInfo
 	
 	[general]
 	# if set to max/2 (no quotes around)
@@ -144,7 +139,7 @@ or if you want a particular release, choose one from https://github.com/fidelram
 	tmp_dir: default
 
 As you can see, deepTools expects samtools to be available via the command ``samtools``,
-as well as the UCSC tools ``bedGraphToBigWig`` and ``bigWigInfo``.
+as well as the UCSC tool ``bedGraphToBigWig``.
 You can either specify the path where you installed the tools in the *.cfg file
 or add the tools to your PATH in your .bashrc file
 (see above for details of the installation of these tools).


### PR DESCRIPTION
We really don't need `bigWigInfo` anymore. In fact, it was breaking things for Vivek since kent's tools aren't as reliable as pyBigWig at remote file access.