### PR TITLE
This should fix #181

### DIFF
--- a/galaxy/wrapper/deepTools_macros.xml
+++ b/galaxy/wrapper/deepTools_macros.xml
@@ -356,7 +356,7 @@ This tool is developed by the `Bioinformatics and Deep-Sequencing Unit`_ at the 
     #if $source.ref_source=="history":
         --genome $source.input1
     #else:
-        --genome "${source.input1_2bit.fields.path}"
+        --genome "$source.input1_2bit.fields.path"
     #end if
     </token>
 


### PR DESCRIPTION
For whatever reason, cheetah doesn't accept the long form `${something}` here, but it does work with the short form.