### PR TITLE
Fix #205 in the next release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,5 @@ include *.txt
 include README.md
 include deeptools/config/deeptools.cfg
 include docs/manual/*
-include examples/*
-include galaxy/*.xml
-include galaxy/tool-data/*
-include galaxy_test_data/*
+exclude examples/*
 include scripts/*

--- a/deeptools/_version.py
+++ b/deeptools/_version.py
@@ -1,4 +1,5 @@
+
 # This file is originally generated from Git information by running 'setup.py
 # version'. Distribution tarballs contain a pre-generated copy of this file.
 
-__version__ = '1.6.0-561'
+__version__ = '1.6.0-602-g9a41c94'


### PR DESCRIPTION
This drastically shrinks the size of the release tarball that can get uploaded to pypi (from ~17MB to <1MB).