### PR TITLE
Don't leave empty files laying around if there's an error

### DIFF
--- a/deeptools/parserCommon.py
+++ b/deeptools/parserCommon.py
@@ -1,5 +1,6 @@
 import argparse
 import deeptools.config as cfg
+import os
 from deeptools._version import __version__
 
 
@@ -272,6 +273,7 @@ def writableFile(string):
     """
     try:
         open(string, 'w').close()
+        os.remove(string)
     except:
         msg = "{} file can be opened for writing".format(string)
         raise argparse.ArgumentTypeError(msg)


### PR DESCRIPTION
`bamCoverage -e -b blah.bam -o foo.bw` shouldn't create an empty `foo.bw` on single-end files. It turns out that many things will create empty files on error, this prevents that.