### PR TITLE
remove --outFileCorMatrix option from plotPCA. This already exists in…

### DIFF
--- a/deeptools/plotPCA.py
+++ b/deeptools/plotPCA.py
@@ -77,10 +77,6 @@ def plotCorrelationArgs():
 
     group = parser.add_argument_group('Output optional options')
 
-    group.add_argument('--outFileCorMatrix',
-                       help='Save correlation matrix to this file.',
-                       metavar='FILE',
-                       type=argparse.FileType('w'))
     return parser
 
 

--- a/deeptools/plotPCA.py
+++ b/deeptools/plotPCA.py
@@ -75,8 +75,6 @@ def plotCorrelationArgs():
     optional.add_argument('--version', action='version',
                           version='%(prog)s {}'.format(__version__))
 
-    group = parser.add_argument_group('Output optional options')
-
     return parser
 
 


### PR DESCRIPTION
… plotCorrelation and there's no point in needlessly calculating a correlation matrix when doing a PCA.

Fixes #229 