### PR TITLE
Set default binSize=10 for most of the tools

### DIFF
--- a/deeptools/parserCommon.py
+++ b/deeptools/parserCommon.py
@@ -194,7 +194,7 @@ def getParentArgParse(args=None, binSize=True):
                               'of the bigwig/bedgraph file.',
                               metavar="INT bp",
                               type=int,
-                              default=50)
+                              default=10)
 
     optional.add_argument('--region', '-r',
                           help='Region of the genome to limit the operation '


### PR DESCRIPTION
The default binSize for many of the tools is 50 (e.g. for bamCoverage). I suggest a smaller binSize, because it should be more in the same range with the default of computeMatrix.
The point I am trying to make is: A bigWig created with bamCoverage (default binSize=50) which is subsequently processed with computeMatrix (default binSize=10) will barely benefit from the smaller 2nd bin size. 
It's just choosing reasonable defaults. Unfortunately, a smaller bin size also increases file size!!!
I leave this open for discussion.