### PR TITLE
removed additional 'g' in front of the 7 digit commit number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def update_version_py():
     if p.returncode != 0:
         print "unable to run git, leaving deeptools/_version.py alone"
         return
-    ver = stdout.strip()
+    ver = stdout.strip().replace("-g", "-")
     f = open("deeptools/_version.py", "w")
     f.write(VERSION_PY % ver)
     f.close()


### PR DESCRIPTION
I removed the additional 'g' in front of the git number. The 'g' is signalling a git repository. An example:
$ computeMatrix --version
Old: computeMatrix 2.0.1-49-gab5d1c4
New: computeMatrix 2.0.1-49-ab5d1c4