### PR TITLE
Add -bs and -n options to BAMPEFragmentSize

### DIFF
--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -40,9 +40,9 @@ def parse_arguments():
                         default='')
     parser.add_argument('--binSize', '-bs',
                         metavar='INT',
-                         help='Length in bases of the window used to sample the genome. (default 1000)',
-                         default=1000,
-                         type=int)
+                        help='Length in bases of the window used to sample the genome. (default 1000)',
+                        default=1000,
+                        type=int)
     parser.add_argument('--distanceBetweenBins', '-n',
                         metavar='INT',
                         help='To reduce the computation time, not every possible genomic '

--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -51,8 +51,8 @@ def parse_arguments():
                         'for high coverage samples, while smaller values are useful for '
                         'lower coverage samples. Note that if you specify a value that '
                         'results in too few (<1000) reads sampled, the value will be '
-                        'decreased. (default 1e6)',
-                        default=1e6,
+                        'decreased. (default 1000000)',
+                        default=1000000,
                         type=int)
     parser.add_argument('--verbose',
                         help='Set if processing data messages are wanted.',

--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -72,20 +72,23 @@ def main(args=None):
                                                                     binSize=args.binSize,
                                                                     distanceBetweenBins=args.distanceBetweenBins)
 
-    if fragment_len_dict['mean'] == 0:
+    if fragment_len_dict:
+        if fragment_len_dict['mean'] == 0:
+            print "No pairs were found. Is the data from a paired-end sequencing experiment?"
+
+        print "Sample size: {}\n".format(fragment_len_dict['sample_size'])
+
+        print "\nFragment lengths:"
+        print "Min.: {}\n1st Qu.: {}\nMean: {}\nMedian: {}\n" \
+              "3rd Qu.: {}\nMax.: {}\nStd: {}".format(fragment_len_dict['min'],
+                                                      fragment_len_dict['qtile25'],
+                                                      fragment_len_dict['mean'],
+                                                      fragment_len_dict['median'],
+                                                      fragment_len_dict['qtile75'],
+                                                      fragment_len_dict['max'],
+                                                      fragment_len_dict['std'])
+    else:
         print "No pairs were found. Is the data from a paired-end sequencing experiment?"
-
-    print "Sample size: {}\n".format(fragment_len_dict['sample_size'])
-
-    print "\nFragment lengths:"
-    print "Min.: {}\n1st Qu.: {}\nMean: {}\nMedian: {}\n" \
-          "3rd Qu.: {}\nMax.: {}\nStd: {}".format(fragment_len_dict['min'],
-                                                  fragment_len_dict['qtile25'],
-                                                  fragment_len_dict['mean'],
-                                                  fragment_len_dict['median'],
-                                                  fragment_len_dict['qtile75'],
-                                                  fragment_len_dict['max'],
-                                                  fragment_len_dict['std'])
 
     print "\nRead lengths:"
     print "Min.: {}\n1st Qu.: {}\nMean: {}\nMedian: {}\n" \

--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -38,11 +38,24 @@ def parse_arguments():
                         help='Title of the plot, to be printed on top of '
                         'the generated image. Leave blank for no title.',
                         default='')
+    parser.add_argument('--binSize', '-bs',
+                        metavar='INT',
+                         help='Length in bases of the window used to sample the genome. (default 1000)',
+                         default=1000,
+                         type=int)
+    parser.add_argument('--distanceBetweenBins', '-n',
+                        metavar='INT',
+                        help='To reduce the computation time, not every possible genomic '
+                        'bin is sampled. This option allows you to set the distance '
+                        'between bins actually sampled from. Larger numbers are sufficient '
+                        'for high coverage samples, while smaller values are useful for '
+                        'lower coverage samples. (default 1e6)',
+                        default=1e6,
+                        type=int)
     parser.add_argument('--verbose',
                         help='Set if processing data messages are wanted.',
                         action='store_true',
                         required=False)
-
     parser.add_argument('--version', action='version',
                         version='%(prog)s {}'.format(__version__))
 
@@ -53,7 +66,9 @@ def main(args=None):
     args = parse_arguments().parse_args(args)
     fragment_len_dict, read_len_dict = get_read_and_fragment_length(args.bam, return_lengths=True,
                                                                     numberOfProcessors=args.numberOfProcessors,
-                                                                    verbose=args.verbose)
+                                                                    verbose=args.verbose,
+                                                                    binSize=args.binSize,
+                                                                    distanceBetweenBins=args.distanceBetweenBins)
 
     if fragment_len_dict['mean'] == 0:
         print "No pairs were found. Is the data from a paired-end sequencing experiment?"

--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -49,7 +49,9 @@ def parse_arguments():
                         'bin is sampled. This option allows you to set the distance '
                         'between bins actually sampled from. Larger numbers are sufficient '
                         'for high coverage samples, while smaller values are useful for '
-                        'lower coverage samples. (default 1e6)',
+                        'lower coverage samples. Note that if you specify a value that '
+                        'results in too few (<1000) reads sampled, the value will be '
+                        'decreased. (default 1e6)',
                         default=1e6,
                         type=int)
     parser.add_argument('--verbose',

--- a/deeptools/getFragmentAndReadSize.py
+++ b/deeptools/getFragmentAndReadSize.py
@@ -51,8 +51,6 @@ def getFragmentLength_worker(chrom, start, end, bamFile, distanceBetweenBins):
     if not len(reads):
         reads = np.array([]).reshape(0, 2)
 
-    if len(reads):
-        print(len(reads))
     return reads
 
 

--- a/deeptools/getFragmentAndReadSize.py
+++ b/deeptools/getFragmentAndReadSize.py
@@ -109,7 +109,7 @@ def get_read_and_fragment_length(bamFile, return_lengths=False,
         else:
             fragment_len_dict = None
 
-        if return_lengths:
+        if return_lengths and fragment_len_dict is not None:
             fragment_len_dict['lengths'] = fragment_length
 
         read_len_dict = {'sample_size': len(read_length),

--- a/deeptools/getFragmentAndReadSize.py
+++ b/deeptools/getFragmentAndReadSize.py
@@ -84,7 +84,7 @@ def get_read_and_fragment_length(bamFile, return_lengths=False,
 
     distanceBetweenBins *= 2
     fl = []
-    while len(fl) == 0 and distanceBetweenBins > 1:
+    while len(fl) < 1000 and distanceBetweenBins > 1:
         distanceBetweenBins /= 2
         stepsize = binSize + distanceBetweenBins
         imap_res = mapReduce.mapReduce((bam_handle.filename, distanceBetweenBins),

--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -16,6 +16,8 @@
                 --histogram ./hist.png
             #end if
             --plotTitle "$plotTitle"
+            --binSize '$binSize'
+            --distanceBetweenBins '$distanceBetweenBins'
             one.bam
             > $outfile
 ]]>
@@ -27,6 +29,17 @@
             label="Get the distribution of fragment lengths as a histogram"
             help=""/>
         <expand macro="plotTitle" />
+        <param name="binSize" type="integer" value="1000" min="1"
+            label="Bin size in bp"
+            help="Length in bases of the window used to sample the genome. (--binSize)"/>
+        <param argument="--distanceBetweenBins" type="integer" value="1000000" min="0"
+            label="Distance between bins"
+            help="To reduce the computation time, not every possible
+                 genomic bin is sampled. This option allows you to set
+                 the distance between bins actually sampled from.
+                 Larger numbers are sufficient for high coverage
+                 samples, while smaller values are useful for lower
+                 coverage samples."/>
     </inputs>
     <outputs>
         <data name="outfile" format="txt"/>

--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -16,8 +16,6 @@
                 --histogram ./hist.png
             #end if
             --plotTitle "$plotTitle"
-            --binSize '$binSize'
-            --distanceBetweenBins '$distanceBetweenBins'
             #if $advancedOpt.showAdvancedOpt == 'yes'
                 --binSize '$advancedOpt.binSize'
                 --distanceBetweenBins '$advancedOpt.distanceBetweenBins'
@@ -55,7 +53,8 @@
                 <param argument="--binSize" type="integer" value="1000" min="1" optional="true"
                     label="bin size, in bases" help="Length in bases of the window used to sample the genome. (--binSize)"/>
                 <param argument="--distanceBetweenBins" type="integer" value="1000000" min="0" optional="true"
-                    label="Bin spacing, in bases" help="To reduce the computation time, not every possible genomic bin is sampled. This option allows you to set the distance between bins actually sampled from. Larger numbers are sufficient for high coverage samples, while smaller values are useful for lower coverage samples. Note that if you specify a value that results in too few (<1000) reads sampled, the value will be decreased. (--distanceBetweenBins)"/>
+                    label="bin spacing, in bases"
+                    help="To reduce the computation time, not every possible genomic bin is sampled. This option allows you to set the distance between bins actually sampled from. Larger numbers are sufficient for high coverage samples, while smaller values are useful for lower coverage samples. Note that if you specify a value that results in too few (&lt;1000) reads sampled, the value will be decreased. (--distanceBetweenBins)"/>
             </when>
         </conditional>
 

--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -31,18 +31,6 @@
             label="Get the distribution of fragment lengths as a histogram"
             help=""/>
         <expand macro="plotTitle" />
-        <param name="binSize" type="integer" value="1000" min="1"
-            label="Bin size in bp"
-            help="Length in bases of the window used to sample the genome. (--binSize)"/>
-        <param argument="--distanceBetweenBins" type="integer" value="1000000" min="0"
-            label="Distance between bins"
-            help="To reduce the computation time, not every possible
-                 genomic bin is sampled. This option allows you to set
-                 the distance between bins actually sampled from.
-                 Larger numbers are sufficient for high coverage
-                 samples, while smaller values are useful for lower
-                 coverage samples."/>
-
         <conditional name="advancedOpt">
             <param name="showAdvancedOpt" type="select" label="Show advanced options" >
                 <option value="no" selected="true">no</option>

--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -18,6 +18,10 @@
             --plotTitle "$plotTitle"
             --binSize '$binSize'
             --distanceBetweenBins '$distanceBetweenBins'
+            #if $advancedOpt.showAdvancedOpt == 'yes'
+                --binSize '$advancedOpt.binSize'
+                --distanceBetweenBins '$advancedOpt.distanceBetweenBins'
+            #end if
             one.bam
             > $outfile
 ]]>
@@ -40,6 +44,21 @@
                  Larger numbers are sufficient for high coverage
                  samples, while smaller values are useful for lower
                  coverage samples."/>
+
+        <conditional name="advancedOpt">
+            <param name="showAdvancedOpt" type="select" label="Show advanced options" >
+                <option value="no" selected="true">no</option>
+                <option value="yes">yes</option>
+            </param>
+            <when value="no" />
+            <when value="yes">
+                <param argument="--binSize" type="integer" value="1000" min="1" optional="true"
+                    label="bin size, in bases" help="Length in bases of the window used to sample the genome. (--binSize)"/>
+                <param argument="--distanceBetweenBins" type="integer" value="1000000" min="0" optional="true"
+                    label="Bin spacing, in bases" help="To reduce the computation time, not every possible genomic bin is sampled. This option allows you to set the distance between bins actually sampled from. Larger numbers are sufficient for high coverage samples, while smaller values are useful for lower coverage samples. Note that if you specify a value that results in too few (<1000) reads sampled, the value will be decreased. (--distanceBetweenBins)"/>
+            </when>
+        </conditional>
+
     </inputs>
     <outputs>
         <data name="outfile" format="txt"/>


### PR DESCRIPTION
fixes #137 by providing `-bs` (`--binSize`) and `-n` (`--distanceBetweenBins`) options to `bamPEFragmentSize`. The current defaults  for these seem reasonable enough, since we really only need a few thousand reads on average.