### PR TITLE
Wrapper fixes

### DIFF
--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -66,13 +66,13 @@
 <![CDATA[
 
 What it does
----------------
+------------
 
 This tool samples a BAM file with paired-end data to estimate the fragment length distribution.
 Properly paired reads are preferred for computation, i.e., unless a region does not contain any concordant pairs, discordant pairs are ignored.
 
 Output
-----------
+------
 
 The **default** output is a simple summary statistic for the observed fragment lengths.
 

--- a/galaxy/wrapper/computeGCBias.xml
+++ b/galaxy/wrapper/computeGCBias.xml
@@ -137,19 +137,19 @@ Output files
 ------------
 
 - Diagnostic plots:
-      - box plot of absolute read numbers per GC-content bin
-      - x-y plot of observed/expected read ratios per GC-content bin
+    - box plot of absolute read numbers per GC-content bin
+    - x-y plot of observed/expected read ratios per GC-content bin
 
 - Tabular file: to be used for GC correction with ``correctGCbias``
 
 .. image:: $PATH_TO_IMAGES/computeGCBias_output.png
-   :width: 600
-   :height: 455
+    :width: 600
+    :height: 455
 
 -----
 
-Background
-----------
+Theoretical Background
+----------------------
 
 ``computeGCBias`` is based on a paper by `Benjamini and Speed <http://nar.oxfordjournals.org/content/40/10/e72>`_.
 The basic assumption of the GC bias diagnosis is that an ideal sample should show a uniform distribution of sequenced reads across the genome, i.e. all regions of the genome should have similar numbers of reads, regardless of their base-pair composition.
@@ -172,8 +172,8 @@ As you can see, both plots based on **simulated reads** do not show enrichments 
 Now, let's have a look at **real-life data** from genomic DNA sequencing. Panels A and B can be clearly distinguished and the major change that took place between the experiments underlying the plots was that the samples in panel A were prepared with too many PCR cycles and a standard polymerase whereas the samples of panel B were subjected to very few rounds of amplification using a high fidelity DNA polymerase.
 
 .. image:: $PATH_TO_IMAGES/QC_GCplots_input.png
-   :width: 600
-   :height: 452
+    :width: 600
+    :height: 452
 
 **Note:** The expected GC profile depends on the reference genome as different organisms have very different GC contents. For example, one would expect more fragments with GC fractions between 30% to 60% in mouse samples (average GC content of the mouse genome: 45 %) than for genome fragments from, for example, *Plasmodium falciparum* (average genome GC content *P. falciparum*: 20%).
 

--- a/galaxy/wrapper/computeGCBias.xml
+++ b/galaxy/wrapper/computeGCBias.xml
@@ -127,14 +127,14 @@
     <help>
 <![CDATA[
 What it does
-------------------
+------------
 
 This tool computes the GC bias using the method proposed in Benjamini and Speed (2012) Nucleic Acids Res. (see below for further details).
 The output is used to plot the results and can also be used later on to correct the bias with the tool ``correctGCbias``.
 There are two plots produced by the tool: a boxplot showing the absolute read numbers per GC-content bin and an x-y plot depicting the ratio of observed/expected reads per GC-content bin.
 
 Output files
---------------
+------------
 
 - Diagnostic plots:
       - box plot of absolute read numbers per GC-content bin
@@ -146,10 +146,10 @@ Output files
    :width: 600
    :height: 455
 
----------------------------------------------
+-----
 
 Background
--------------
+----------
 
 ``computeGCBias`` is based on a paper by `Benjamini and Speed <http://nar.oxfordjournals.org/content/40/10/e72>`_.
 The basic assumption of the GC bias diagnosis is that an ideal sample should show a uniform distribution of sequenced reads across the genome, i.e. all regions of the genome should have similar numbers of reads, regardless of their base-pair composition.

--- a/galaxy/wrapper/plotCorrelation.xml
+++ b/galaxy/wrapper/plotCorrelation.xml
@@ -94,8 +94,8 @@ What it does
 This tools takes the default output of ``multiBamSummary`` or ``multiBigwigSummary``, and computes the pairwise correlation among samples.
 Results can be visualized as **scatterplots** or as a **heatmap** of correlation coefficients (see below for examples).
 
-Background
-----------
+Theoretical Background
+----------------------
 
 The result of the correlation computation is a **table of correlation coefficients** that indicates how "strong" the relationship between two samples is and it will consist of numbers between -1 and 1. (-1 indicates perfect anti-correlation, 1 perfect correlation.)
 
@@ -105,18 +105,18 @@ The *Pearson method* measures the **metric differences** between samples and is 
 The *Spearman method* is based on **rankings**.
 
 Output
---------
+------
 
 The default output is a **diagnostic plot** -- either a scatterplot or a clustered heatmap displaying the values for each pair-wise correlation (see below for example plots).
 
 Optionally, you can also obtain a table of the pairwise correlation coefficients.
 
 .. image:: $PATH_TO_IMAGES/plotCorrelation_output.png
-   :width: 600
-   :height: 271
+    :width: 600
+    :height: 271
 
 Example plots
---------------
+-------------
 
 The following is the output of ``plotCorrelation`` with our test ChIP-Seq datasets (to be found under "Shared Data" --> "Data Library").
 
@@ -124,14 +124,14 @@ Average coverages were computed over 10 kb bins for chromosome X,
 from bigWig files using ``multiBigwigSummary``. This was then used with ``plotCorrelation`` to make a heatmap of Spearman correlation coefficients.
 
 .. image:: $PATH_TO_IMAGES/plotCorrelation_galaxy_bw_heatmap_output.png
-   :width: 600
-   :height: 518
+    :width: 600
+    :height: 518
 
 The scatterplot could look like this:
 
 .. image:: $PATH_TO_IMAGES/plotCorrelation_scatterplot_PearsonCorr_bigwigScores.png
-   :width: 600
-   :height: 600
+    :width: 600
+    :height: 600
 
 -----
 

--- a/galaxy/wrapper/plotCorrelation.xml
+++ b/galaxy/wrapper/plotCorrelation.xml
@@ -89,14 +89,13 @@
     <help>
 <![CDATA[
 What it does
---------------
+------------
 
 This tools takes the default output of ``multiBamSummary`` or ``multiBigwigSummary``, and computes the pairwise correlation among samples.
-Results can be visualized as **scatterplots** or as
-a **heatmap** of correlation coefficients (see below for examples).
+Results can be visualized as **scatterplots** or as a **heatmap** of correlation coefficients (see below for examples).
 
 Background
-------------
+----------
 
 The result of the correlation computation is a **table of correlation coefficients** that indicates how "strong" the relationship between two samples is and it will consist of numbers between -1 and 1. (-1 indicates perfect anti-correlation, 1 perfect correlation.)
 

--- a/galaxy/wrapper/plotFingerprint.xml
+++ b/galaxy/wrapper/plotFingerprint.xml
@@ -144,8 +144,8 @@ What follows is the output of ``plotFingerprint`` with our test ChIP-Seq data se
 
 -----
 
-Background
-----------
+Theoretical Background
+----------------------
 
 The tool first samples indexed BAM files and counts all reads overlapping a window (bin) of the specified length.
 These counts are then sorted according to their rank (the bin with the highest number of reads has the highest rank)

--- a/galaxy/wrapper/plotFingerprint.xml
+++ b/galaxy/wrapper/plotFingerprint.xml
@@ -114,14 +114,14 @@
 
 
 What it does
----------------
+------------
 
 This tool is useful for assessing the strength of a ChIP (i.e. how clearly the enrichment signal can be separated from the background)
 and is based on a method described in Diaz et al. (2012) Stat Appl Genet Mol Biol 11(3).
 
 
 Output
----------
+------
 
 The default output is a diagnostic plot (see below for an example and further down for some background information).
 
@@ -142,10 +142,10 @@ What follows is the output of ``plotFingerprint`` with our test ChIP-Seq data se
    :width: 600
    :height: 450
 
------------------------------
+-----
 
 Background
---------------
+----------
 
 The tool first samples indexed BAM files and counts all reads overlapping a window (bin) of the specified length.
 These counts are then sorted according to their rank (the bin with the highest number of reads has the highest rank)

--- a/galaxy/wrapper/plotPCA.xml
+++ b/galaxy/wrapper/plotPCA.xml
@@ -36,7 +36,7 @@
 What it does
 ------------
 
-This tool takes the **default output file of ``multiBamSummary``** or ``multiBigwigSummary`` to perform a principal component analysis (PCA).
+This tool takes the **default output file** of ``multiBamSummary`` or ``multiBigwigSummary`` to perform a principal component analysis (PCA).
 
 Output
 ------
@@ -55,8 +55,8 @@ Example plot
 
 -----
 
-Background
-----------
+Theoretical Background
+----------------------
 
 Principal component analysis (PCA) can be used, for example, to determine whether **samples display greater variability** between experimental conditions than between replicates of the same treatment. PCA is also useful to identify unexpected patterns, such as those caused by batch effects or outliers.
 Principal components represent the directions along which the variation in the data is maximal, so that the information (e.g., read coverage values) from thousands of regions can be represented by just a few dimensions.

--- a/galaxy/wrapper/plotPCA.xml
+++ b/galaxy/wrapper/plotPCA.xml
@@ -34,12 +34,12 @@
 <![CDATA[
 
 What it does
----------------
+------------
 
 This tool takes the **default output file of ``multiBamSummary``** or ``multiBigwigSummary`` to perform a principal component analysis (PCA).
 
 Output
--------------
+------
 
 The result is a panel of two plots:
 
@@ -47,16 +47,16 @@ The result is a panel of two plots:
 2. The **Scree plot** for the top five principal components where the bars represent the amount of variability explained by the individual factors and the red line traces the amount of variability is explained by the individual components in a cumulative manner
 
 Example plot
----------------
+------------
 
 .. image:: $PATH_TO_IMAGES/plotPCA_annotated.png
    :width: 600
    :height: 315
 
-===================
+-----
 
 Background
------------------
+----------
 
 Principal component analysis (PCA) can be used, for example, to determine whether **samples display greater variability** between experimental conditions than between replicates of the same treatment. PCA is also useful to identify unexpected patterns, such as those caused by batch effects or outliers.
 Principal components represent the directions along which the variation in the data is maximal, so that the information (e.g., read coverage values) from thousands of regions can be represented by just a few dimensions.


### PR DESCRIPTION
It turns out that any of the wrappers with a "Background" section were rendering incorrectly. For some reason, the "Background" section kept getting rendered at the top of the page!?!

I have no clue why this was happening, it's presumably a bug in how Galaxy renders things.