### PR TITLE
Start adding blacklist functionality to the Galaxy wrapper (fixes #342)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@
  * The API for the countReadsPerBin, getScorePerBigWigBin, and mapReduce modules has changed slightly (this was needed to support the --metagene option). Anyone using these in their own programs is encouraged to look at the modified API before upgrading.
  * Added the `plotEnrichment` function (this was issue #329).
  * There is now a `subsetMatrix` script available that can be used to subset the output of computeMatrix. This is useful for preparing plots that only contain a subset of samples/region groups. Note that this isn't installed by default.
+ * The Galaxy wrappers were updated to include the ability to exclude blacklisted regions.
 
 2.2.3
 

--- a/galaxy/wrapper/bamCompare.xml
+++ b/galaxy/wrapper/bamCompare.xml
@@ -65,6 +65,8 @@
                 #if str($advancedOpt.ignoreForNormalization).strip() != '':
                     --ignoreForNormalization '$advancedOpt.ignoreForNormalization'
                 #end if
+
+                @blacklist@
             #end if
 ]]>
     </command>
@@ -166,6 +168,7 @@
                         For example, if you know of copy number variations between samples then you may want to exclude these.
                         Another typical example is the difference in chromosome X copies between males and females in many species.
                         Example inputs are chrX,chrY,chr3 or chr10:12220-128932" />
+                <expand macro="blacklist" />
             </when>
         </conditional>
     </inputs>

--- a/galaxy/wrapper/bamCoverage.xml
+++ b/galaxy/wrapper/bamCoverage.xml
@@ -50,6 +50,8 @@
                 #if str($advancedOpt.filterRNAstrand) != 'no':
                     --filterRNAstrand '$advancedOpt.filterRNAstrand'
                 #end if
+
+                @blacklist@
             #end if
 ]]>
     </command>
@@ -116,6 +118,7 @@
                     <option value="forward">forward</option>
                     <option value="reverse">reverse</option>
                 </param>
+                <expand macro="blacklist" />
 
             </when>
         </conditional>

--- a/galaxy/wrapper/bamPEFragmentSize.xml
+++ b/galaxy/wrapper/bamPEFragmentSize.xml
@@ -19,6 +19,7 @@
             #if $advancedOpt.showAdvancedOpt == 'yes'
                 --binSize '$advancedOpt.binSize'
                 --distanceBetweenBins '$advancedOpt.distanceBetweenBins'
+                @blacklist@
             #end if
             one.bam
             > $outfile
@@ -43,6 +44,7 @@
                 <param argument="--distanceBetweenBins" type="integer" value="1000000" min="0" optional="true"
                     label="bin spacing, in bases"
                     help="To reduce the computation time, not every possible genomic bin is sampled. This option allows you to set the distance between bins actually sampled from. Larger numbers are sufficient for high coverage samples, while smaller values are useful for lower coverage samples. Note that if you specify a value that results in too few (&lt;1000) reads sampled, the value will be decreased. (--distanceBetweenBins)"/>
+                <expand macro="blacklist" />
             </when>
         </conditional>
 

--- a/galaxy/wrapper/bigwigCompare.xml
+++ b/galaxy/wrapper/bigwigCompare.xml
@@ -34,6 +34,7 @@
                 #if $advancedOpt.plotTitle and str($advancedOpt.plotTitle.value) != "":
                     --plotTitle '$advancedOpt.plotTitle'
                 #end if
+                @blacklist@
 
             #end if
 ]]>
@@ -94,6 +95,7 @@
                 <expand macro="skipNAs" />
                 <expand macro="scaleFactors" />
                 <expand macro="plotTitle" />
+                <expand macro="blacklist" />
             </when>
         </conditional>
     </inputs>

--- a/galaxy/wrapper/computeGCBias.xml
+++ b/galaxy/wrapper/computeGCBias.xml
@@ -39,6 +39,8 @@
                 #if $advancedOpt.extraSampling:
                     --extraSampling $advancedOpt.extraSampling
                 #end if
+
+                @blacklist@
             #end if
 
             #if str($image_format) != 'none':
@@ -81,6 +83,7 @@
                 <param name="extraSampling" type="data" format="bed" optional="true"
                     label="BED file containing genomic regions for which extra sampling is required because they are underrepresented in the genome"
                     help="(--extraSampling)" />
+                <expand macro="blacklist" />
             </when>
         </conditional>
         <param name="image_format" type="select"

--- a/galaxy/wrapper/computeMatrix.xml
+++ b/galaxy/wrapper/computeMatrix.xml
@@ -79,6 +79,8 @@
 
                 @ADVANCED_OPTS_GTF@
 
+                @blacklist@
+
             #end if
 ]]>
     </command>
@@ -212,6 +214,7 @@
 
                 <expand macro="gtf_options" />
 
+                <expand macro="blacklist" />
             </when>
         </conditional>
     </inputs>

--- a/galaxy/wrapper/multiBamSummary.xml
+++ b/galaxy/wrapper/multiBamSummary.xml
@@ -37,6 +37,7 @@
             #if $advancedOpt.showAdvancedOpt == "yes":
                 @ADVANCED_OPTS_READ_PROCESSING@
                 @ADVANCED_OPTS_GTF@
+                @blacklist@
             #end if
 ]]>
     </command>
@@ -74,6 +75,7 @@
         <expand macro="advancedOpt_scaffold">
             <expand macro="read_processing_options" />
             <expand macro="gtf_options" />
+            <expand macro="blacklist" />
         </expand>
 
         <param argument="--outRawCounts" type="boolean" label="Save raw counts (coverages) to file" help=""/>

--- a/galaxy/wrapper/multiBigwigSummary.xml
+++ b/galaxy/wrapper/multiBigwigSummary.xml
@@ -38,6 +38,7 @@
 
             #if $advancedOpt.showAdvancedOpt == "yes":
                 @ADVANCED_OPTS_GTF@
+                @blacklist@
             #end if
 ]]>
     </command>
@@ -73,6 +74,7 @@
 
         <expand macro="advancedOpt_scaffold">
             <expand macro="gtf_options" />
+            <expand macro="blacklist" />
         </expand>
 
     </inputs>

--- a/galaxy/wrapper/plotCoverage.xml
+++ b/galaxy/wrapper/plotCoverage.xml
@@ -38,6 +38,7 @@
                     --plotTitle '$advancedOpt.plotTitle'
                 #end if
                 @ADVANCED_OPTS_READ_PROCESSING@
+                @blacklist@
             #end if
 
 ]]>
@@ -60,6 +61,7 @@
                 <expand macro="read_processing_options" />
                 <expand macro="skipZeros" />
                 <expand macro="plotTitle" />
+                <expand macro="blacklist" />
             </when>
         </conditional>
 

--- a/galaxy/wrapper/plotFingerprint.xml
+++ b/galaxy/wrapper/plotFingerprint.xml
@@ -42,6 +42,7 @@
                     --plotTitle '$advancedOpt.plotTitle'
                 #end if
                 @ADVANCED_OPTS_READ_PROCESSING@
+                @blacklist@
             #end if
 ]]>
     </command>
@@ -66,6 +67,7 @@
                 <expand macro="read_processing_options" />
                 <expand macro="skipZeros" />
                 <expand macro="plotTitle" />
+                <expand macro="blacklist" />
             </when>
         </conditional>
 


### PR DESCRIPTION
Fixes #342 and also the correctGCBias travis test, which previously failed due to having an old version of twobitreader.