### PR TITLE
Use `element_identifier` to label samples according to their name in …

### DIFF
--- a/galaxy/wrapper/computeMatrix.xml
+++ b/galaxy/wrapper/computeMatrix.xml
@@ -7,17 +7,20 @@
     <expand macro="requirements" />
     <command>
 <![CDATA[
+        #import re
         #import tempfile
         #set bw_files=[]
-        #for $counter, $bigwig in enumerate($scoreFileName):
-            ln -s "${bigwig}" "file_${counter}.bw" &&
-            #silent $bw_files.append('file_%s.bw' % $counter)
+        #for $counter, $bigwig, in enumerate($scoreFileName):
+            #set identifier = re.sub('[^\s\w\-]', '_', str($bigwig.element_identifier))
+            ln -f -s "${bigwig}" "${identifier}_${counter}.bw" &&
+            #silent $bw_files.append('%s_%s.bw' % ($identifier, $counter))
         #end for
 
         #set bed_files=[]
-        #for $counter, $rf in enumerate($regionsFiles):
-            ln -s "${rf.regionsFile}" "group_${counter}.bed" &&
-            #silent $bed_files.append('group_%s.bed' % $counter)
+        #for $counter, $rf, in enumerate($regionsFiles):
+            #set identifier = re.sub('[^\s\w\-]', '_', str($rf.regionsFile.element_identifier))
+            ln -f -s "${rf.regionsFile}" "${identifier}_${counter}.bed" &&
+            #silent $bed_files.append('%s_%s.bed' % ($identifier, $counter))
         #end for
 
         @BINARY@


### PR DESCRIPTION
…the history

With this change you get the history name or the collection elements' element_identifier as label (unless overriden with a custom name). This is really helpful for us when we have a bunch of samples in a collection, we don't have to be careful to not mislabel samples.