### PR TITLE
fixed debug global bug and shutil bedgraph join bug in correctGCBias

### DIFF
--- a/deeptools/correctGCBias.py
+++ b/deeptools/correctGCBias.py
@@ -243,8 +243,8 @@ def writeCorrected_worker(chrNameBam, chrNameBit, start, end, step):
             endTime = time.time()
             print("{}, processing {} ({:.1f} per sec) ")
             "reads @ {}:{}-{}".format(multiprocessing.current_process().name,
-                                    i, i / (endTime - startTime),
-                                    chrNameBit, start, end)
+                                      i, i / (endTime - startTime),
+                                      chrNameBit, start, end)
     except NameError:
         pass
 

--- a/deeptools/correctGCBias.py
+++ b/deeptools/correctGCBias.py
@@ -237,12 +237,16 @@ def writeCorrected_worker(chrNameBam, chrNameBit, start, end, step):
 
         cvg_corr[vectorStart:vectorEnd] += float(1) / R_gc[gc]
         i += 1
-    if debug:
-        endTime = time.time()
-        print("{}, processing {} ({:.1f} per sec) ")
-        "reads @ {}:{}-{}".format(multiprocessing.current_process().name,
-                                  i, i / (endTime - startTime),
-                                  chrNameBit, start, end)
+
+    try:
+        if debug:
+            endTime = time.time()
+            print("{}, processing {} ({:.1f} per sec) ")
+            "reads @ {}:{}-{}".format(multiprocessing.current_process().name,
+                                    i, i / (endTime - startTime),
+                                    chrNameBit, start, end)
+    except NameError:
+        pass
 
     if i == 0:
         return None
@@ -661,7 +665,7 @@ def main(args=None):
             res = list(map(writeCorrected_wrapper, mp_args))
 
         # concatenate intermediary bedgraph files
-        _temp_bg_file = open(_temp_bg_file_name, 'w')
+        _temp_bg_file = open(_temp_bg_file_name, 'wb')
         for tempFileName in res:
             if tempFileName:
                 # concatenate all intermediate tempfiles into one


### PR DESCRIPTION
I received two errors when running correctGCBias using python3.5 on ubuntu14.

This PR addresses those 2 errors:
1) The debug global is not assigned if the script is run without using the Tester Class. I added a try/except statement to catch it.

2) The shutil.copyfileobj method needs binary files for both the source and destination file. I modified this accordingly.

All appears to be in working order after these modifications. Thanks for the great work.

--Adam
adam.drake@freenome.com