### PR TITLE
--filterRNAstrand help text

### DIFF
--- a/deeptools/bamCoverage.py
+++ b/deeptools/bamCoverage.py
@@ -98,7 +98,7 @@ def get_optional_args():
                           required=False)
 
     optional.add_argument('--filterRNAstrand',
-                          help='Selects RNA-seq reads (single-end or paired-end) in '
+                          help='Exclude RNA-seq reads (single-end or paired-end) from '
                                'the given strand.',
                           choices=['forward', 'reverse'],
                           default=None)


### PR DESCRIPTION
Currently the help text for `--filterRNAstrand` is:

```
--filterRNAstrand {forward,reverse}
                        Selects RNA-seq reads (single-end or paired-end) in
                        the given strand. (default: None)
```

From this it's unclear whether reads are _selected_ or reads are _selected for removal_. This minor change clarifies the behavior of the argument.
